### PR TITLE
FIX: handleMousedown function in useResize hook to use React.MouseEve…

### DIFF
--- a/src/shared/hooks/useResize.ts
+++ b/src/shared/hooks/useResize.ts
@@ -52,7 +52,7 @@ function useResize() {
 		document.removeEventListener("mouseup", handleMouseUp);
 	};
 
-	const handleMousedown = (e: MouseEvent) => {
+	const handleMousedown = (e: React.MouseEvent<HTMLElement>) => {
 		e.stopPropagation();
 		e.preventDefault();
 


### PR DESCRIPTION
…nt<HTMLElement> instead of MouseEvent